### PR TITLE
chore(deps): specify minimum openssl package version (avoid CVE-2023-…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ HEALTHCHECK --interval=30m --timeout=60s --start-period=5s \
   CMD curl -f http://${HEALTH_CHECK_USERNAME}:${HEALTH_CHECK_PASSWORD}@localhost:3000/health_check.txt || exit 1
 
 RUN apk add --no-cache --verbose \
-  'git=~2' \
-  'make=~4' \
   'gcc>=12' \
+  'git=~2' \
   'libc-dev=~0' \
+  'make=~4' \
+  'openssl>=3.1.4' \
   'tzdata>=2023c-r1'
 
 ARG USER=html2rss


### PR DESCRIPTION
…5363)

Docker Scout detected this.