### PR TITLE
ci(docker): set timestamp for reproducible builds

### DIFF
--- a/.github/workflows/test_build_push.yml
+++ b/.github/workflows/test_build_push.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get Git commit timestamps
+        run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
@@ -82,6 +85,8 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
         with:
           context: .
           push: true


### PR DESCRIPTION
Introduces a step to retrieve the latest git commit timestamp and store it in the environment. This timestamp is used as `SOURCE_DATE_EPOCH` during Docker image build to ensure reproducible builds by standardizing the build date.

This change improves build consistency and traceability.

https://docs.docker.com/build/ci/github-actions/reproducible-builds/