### PR TITLE
ci(docker): extract metadata and enable sbom in build

### DIFF
--- a/.github/workflows/test_build_push.yml
+++ b/.github/workflows/test_build_push.yml
@@ -44,7 +44,7 @@ jobs:
           bundle exec rake
 
   docker-push:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    # if: ${{ github.ref == 'refs/heads/master' }}
     needs:
       - docker-test
       - hadolint

--- a/.github/workflows/test_build_push.yml
+++ b/.github/workflows/test_build_push.yml
@@ -44,7 +44,7 @@ jobs:
           bundle exec rake
 
   docker-push:
-    # if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs:
       - docker-test
       - hadolint
@@ -95,7 +95,7 @@ jobs:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
         with:
           context: .
-          push: false
+          push: true
           tags: |
             gilcreator/html2rss-web:latest
             gilcreator/html2rss-web:${{ github.sha }}
@@ -113,19 +113,7 @@ jobs:
             org.opencontainers.image.description=Generates RSS feeds of any website & serves to the web!
             org.opencontainers.image.sbom=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts
 
-      # - name: Generate SBOM
-      #   uses: anchore/sbom-action@v0.20.1
-      #   with:
-      #     image: gilcreator/html2rss-web:${{ github.sha }}
-      #     output-file: sbom.spdx.json
-
-      # - name: Upload SBOM Artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: sbom
-      #     path: sbom.spdx.json
-
-      # - name: Move updated cache into place
-      #   run: |
-      #     rm -rf /tmp/.buildx-cache
-      #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Move updated cache into place
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/test_build_push.yml
+++ b/.github/workflows/test_build_push.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Get Git commit timestamps
         run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
 
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
@@ -89,14 +95,16 @@ jobs:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
         with:
           context: .
-          push: true
+          push: false
           tags: |
             gilcreator/html2rss-web:latest
             gilcreator/html2rss-web:${{ github.sha }}
+            ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           provenance: true
+          sbom: true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
@@ -105,19 +113,19 @@ jobs:
             org.opencontainers.image.description=Generates RSS feeds of any website & serves to the web!
             org.opencontainers.image.sbom=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts
 
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0.20.1
-        with:
-          image: gilcreator/html2rss-web:${{ github.sha }}
-          output-file: sbom.spdx.json
+      # - name: Generate SBOM
+      #   uses: anchore/sbom-action@v0.20.1
+      #   with:
+      #     image: gilcreator/html2rss-web:${{ github.sha }}
+      #     output-file: sbom.spdx.json
 
-      - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sbom
-          path: sbom.spdx.json
+      # - name: Upload SBOM Artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: sbom
+      #     path: sbom.spdx.json
 
-      - name: Move updated cache into place
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      # - name: Move updated cache into place
+      #   run: |
+      #     rm -rf /tmp/.buildx-cache
+      #     mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Please refer to [html2rss' README for a description of _the feed config and its 
 This web application is distributed in a [rolling release](https://en.wikipedia.org/wiki/Rolling_release) fashion from the `master` branch.
 
 For the latest commit passing GitHub CI/CD on the master branch, an updated Docker image will be pushed to [Docker Hub: `gilcreator/html2rss-web`](https://hub.docker.com/r/gilcreator/html2rss-web).
-The [SBOM](https://en.wikipedia.org/wiki/Software_supply_chain) is embedded as an OCI label in the Docker image and is [also available as a build artifact](https://github.com/html2rss/html2rss-web/actions/workflows/test_build_push.yml?query=branch%3Amaster).
+The [SBOM](https://en.wikipedia.org/wiki/Software_supply_chain) is embedded in the Docker image.
 
 GitHub's @dependabot is enabled for dependency updates and they are automatically merged to the `master` branch when the CI gives the green light.
 


### PR DESCRIPTION
Integrates `docker/metadata-action` to extract image metadata and use its outputs for tagging.

Enables SBOM generation to enhance security and compliance.

Improves image tagging by including metadata outputs and retains multi-platform support.

https://docs.docker.com/build/ci/github-actions/attestations/