### PR TITLE
fix(web): use relative Link targets to stop Host DNS leaks

### DIFF
--- a/app/web/feeds/renderer.rb
+++ b/app/web/feeds/renderer.rb
@@ -115,25 +115,15 @@ module Html2rss
           # @param request [Rack::Request]
           # @return [void]
           def apply_alternate_links(response, request)
+            # Path-absolute relative targets (RFC 8288) so reverse-proxy Host/DNS cannot leak.
             base_path = FormatNegotiation.strip_known_extension(FormatNegotiation.request_path(request))
-            base_url = request_base_url(request)
-            rss_url = "#{base_url}#{base_path}.xml"
-            json_url = "#{base_url}#{base_path}.json"
+            rss_url = "#{base_path}.xml"
+            json_url = "#{base_path}.json"
 
             response['Link'] = [
               "<#{rss_url}>; rel=\"alternate\"; type=\"application/rss+xml\"",
               "<#{json_url}>; rel=\"alternate\"; type=\"application/feed+json\""
             ].join(', ')
-          end
-
-          # @param request [Rack::Request]
-          # @return [String]
-          def request_base_url(request)
-            return request.base_url if request.respond_to?(:base_url)
-
-            scheme = request.env['rack.url_scheme']
-            host = request.env['HTTP_HOST']
-            "#{scheme}://#{host}"
           end
 
           # @param result [Html2rss::Web::Feeds::Contracts::RenderResult]
@@ -156,7 +146,7 @@ module Html2rss
           def canonical_feed_url(request)
             return unless request
 
-            "#{request_base_url(request)}#{FormatNegotiation.request_path(request)}"
+            "#{request.base_url}#{FormatNegotiation.request_path(request)}"
           end
 
           # @param result [Html2rss::Web::Feeds::Contracts::RenderResult]

--- a/spec/html2rss/web/api/v1_spec.rb
+++ b/spec/html2rss/web/api/v1_spec.rb
@@ -139,6 +139,15 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     ].map { |path, title, description| { 'path' => path, 'title' => title, 'description' => description } }
   end
 
+  # @param token [String]
+  # @return [String]
+  def relative_feed_link_header(token)
+    [
+      "</api/v1/feeds/#{token}.xml>; rel=\"alternate\"; type=\"application/rss+xml\"",
+      "</api/v1/feeds/#{token}.json>; rel=\"alternate\"; type=\"application/feed+json\""
+    ].join(', ')
+  end
+
   around do |example|
     ClimateControl.modify(AUTO_SOURCE_ENABLED: 'true') { example.run }
   end
@@ -394,29 +403,23 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
 
       expect(last_response.status).to eq(200)
       expect(last_response.headers['Vary']).to include('Accept', 'Host')
-      expect(last_response.headers['Link']).to eq(
-        '<http://example.test/api/v1/feeds/' \
-        "#{token}.xml>; rel=\"alternate\"; type=\"application/rss+xml\", " \
-        '<http://example.test/api/v1/feeds/' \
-        "#{token}.json>; rel=\"alternate\"; type=\"application/feed+json\""
-      )
+      expect(last_response.headers['Link']).to eq(relative_feed_link_header(token))
     end
 
-    it 'varies absolute Link and JSON feed_url by Host', :aggregate_failures do
+    it 'uses relative Link targets and varies JSON feed_url by Host', :aggregate_failures do
       token = Html2rss::Web::Auth.generate_feed_token('admin', "#{feed_url}/host-vary", strategy: 'faraday')
       feed = link_header_feed_double
-      allow(Html2rss::Web::Feeds::Service).to receive(:call).and_return(
-        ok_render_result(feed: feed, cache_key: 'feed_result:host-vary')
-      )
+      allow(Html2rss::Web::Feeds::Service).to receive(:call)
+        .and_return(ok_render_result(feed: feed, cache_key: 'feed_result:host-vary'))
 
       get "/api/v1/feeds/#{token}.json", {}, { 'HTTP_HOST' => 'feeds.example.test' }
 
       expect(last_response.status).to eq(200)
       expect(last_response.headers['Vary']).to include('Accept', 'Host')
-      expect(last_response.headers['Link']).to include('http://feeds.example.test/')
-      expect(feed).to have_received(:to_json_feed).with(
-        feed_url: "http://feeds.example.test/api/v1/feeds/#{token}.json"
-      )
+      expect(last_response.headers['Link']).to eq(relative_feed_link_header(token))
+      expect(last_response.headers['Link']).not_to include('feeds.example.test')
+      expect(feed).to have_received(:to_json_feed)
+        .with(feed_url: "http://feeds.example.test/api/v1/feeds/#{token}.json")
     end
 
     it 'renders json feed for a valid token when requested through Accept', :aggregate_failures do

--- a/spec/html2rss/web/feeds/feed_result_integration_spec.rb
+++ b/spec/html2rss/web/feeds/feed_result_integration_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe 'FeedResult pipeline integration' do
     expect_json_render(service_result)
   end
 
-  it 'varies success Link and feed_url by Host', :aggregate_failures do
+  # rubocop:disable RSpec/ExampleLength -- Link host-leak + feed_url Host vary asserted together
+  it 'keeps relative Link targets while varying JSON feed_url by Host', :aggregate_failures do
     expect(service_result.status).to eq(:ok)
 
     other_host_response = Rack::Response.new
@@ -59,11 +60,14 @@ RSpec.describe 'FeedResult pipeline integration' do
       request: other_host_request
     )
     json = JSON.parse(body)
+    base_path = '/api/v1/feeds/integration-token'
 
     expect(other_host_response['Vary']).to include('Accept', 'Host')
-    expect(other_host_response['Link']).to include('http://feeds.other.test/')
+    expect(other_host_response['Link']).to eq(expected_link_header(base_path: base_path))
+    expect(other_host_response['Link']).not_to include('feeds.other.test')
     expect(json['feed_url']).to eq('http://feeds.other.test/api/v1/feeds/integration-token.json')
   end
+  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable RSpec/ExampleLength -- asserts empty status, channel title, plain body, and Vary together
   it 'prefers channel_title for empty scrape plain-text bodies', :aggregate_failures do
@@ -108,7 +112,7 @@ RSpec.describe 'FeedResult pipeline integration' do
     expect(
       [response.status, response['Content-Type'], response['Vary'], response['Link'], body.include?('Integration Item')]
     ).to eq(
-      [200, 'application/xml', 'Accept, Host', expected_link_header(host: 'example.test', base_path: base_path), true]
+      [200, 'application/xml', 'Accept, Host', expected_link_header(base_path: base_path), true]
     )
   end
 
@@ -135,13 +139,12 @@ RSpec.describe 'FeedResult pipeline integration' do
     Rack::Request.new(Rack::MockRequest.env_for(path, 'HTTP_HOST' => host))
   end
 
-  # @param host [String]
   # @param base_path [String]
   # @return [String]
-  def expected_link_header(host:, base_path:)
+  def expected_link_header(base_path:)
     [
-      "<http://#{host}#{base_path}.xml>; rel=\"alternate\"; type=\"application/rss+xml\"",
-      "<http://#{host}#{base_path}.json>; rel=\"alternate\"; type=\"application/feed+json\""
+      "<#{base_path}.xml>; rel=\"alternate\"; type=\"application/rss+xml\"",
+      "<#{base_path}.json>; rel=\"alternate\"; type=\"application/feed+json\""
     ].join(', ')
   end
 end

--- a/spec/html2rss/web/feeds/renderer_spec.rb
+++ b/spec/html2rss/web/feeds/renderer_spec.rb
@@ -112,11 +112,20 @@ RSpec.describe Html2rss::Web::Feeds::Renderer do
       expect(response).to have_received(:[]=).with('Content-Type', 'application/xml')
       expect(response).to have_received(:[]=).with(
         'Link',
-        '<http://example.test/api/v1/feeds/token.xml>; rel="alternate"; type="application/rss+xml", ' \
-        '<http://example.test/api/v1/feeds/token.json>; rel="alternate"; type="application/feed+json"'
+        '</api/v1/feeds/token.xml>; rel="alternate"; type="application/rss+xml", ' \
+        '</api/v1/feeds/token.json>; rel="alternate"; type="application/feed+json"'
       )
       expect(Html2rss::Web::HttpCache).to have_received(:vary).with(response, 'Accept', 'Host')
       expect(Html2rss::Web::HttpCache).to have_received(:expires).with(response, 300, cache_control: 'public')
+    end
+
+    it 'omits reverse-proxy Docker DNS Hosts from Link targets' do
+      env = Rack::MockRequest.env_for('/api/v1/feeds/token.xml', 'HTTP_HOST' => 'html2rss-web-app-1:4000')
+      proxied_response = Rack::Response.new
+
+      described_class.render(ok_result, response: proxied_response, request: Rack::Request.new(env))
+
+      expect(proxied_response['Link']).not_to include('html2rss-web-app-1')
     end
 
     it 'prefers json feed from Accept when path has no format suffix' do


### PR DESCRIPTION
Absolute Host-derived Link headers exposed internal Docker DNS names when a reverse proxy forwarded the upstream Host.