### PR TITLE
feat: drop browserless

### DIFF
--- a/app/web/api/v1/strategies.rb
+++ b/app/web/api/v1/strategies.rb
@@ -34,7 +34,7 @@ module Html2rss
             def display_name_for(name)
               case name.to_s
               when 'faraday' then 'Default'
-              when 'browserless' then 'JavaScript pages (recommended)'
+              when 'botasaurus' then 'Browser (Botasaurus)'
               else name.to_s.split('_').map(&:capitalize).join(' ')
               end
             end

--- a/app/web/errors/error_classifier.rb
+++ b/app/web/errors/error_classifier.rb
@@ -122,10 +122,8 @@ module Html2rss
              c.any?(::Html2rss::RequestService::BlockedSurfaceDetected)
          }, BLOCKED_SURFACE],
         [lambda { |c, _|
-           (defined?(::Html2rss::RequestService::BotasaurusConnectionFailed) &&
-             c.any?(::Html2rss::RequestService::BotasaurusConnectionFailed)) ||
-             (defined?(::Html2rss::RequestService::BrowserlessConnectionFailed) &&
-               c.any?(::Html2rss::RequestService::BrowserlessConnectionFailed))
+           defined?(::Html2rss::RequestService::BotasaurusConnectionFailed) &&
+             c.any?(::Html2rss::RequestService::BotasaurusConnectionFailed)
          }, SCRAPER_UNAVAILABLE],
         [lambda { |_, err|
            defined?(::Rack::Timeout::RequestTimeoutException) && err.is_a?(::Rack::Timeout::RequestTimeoutException)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ services:
       SENTRY_ENABLE_LOGS: ${SENTRY_ENABLE_LOGS:-false}
       HTML2RSS_TOTAL_TIMEOUT_SECONDS: 25
       RACK_TIMEOUT_SERVICE_TIMEOUT: 30
-      BROWSERLESS_IO_WEBSOCKET_URL: ws://browserless:4002
-      BROWSERLESS_IO_API_TOKEN: ${BROWSERLESS_IO_API_TOKEN:?set BROWSERLESS_IO_API_TOKEN}
+      BOTASAURUS_SCRAPER_URL: http://botasaurus:4010
     # Trial runs use the image's bundled config/feeds.yml.
     # Uncomment the block below when you want to replace it with your own file.
     # volumes:
@@ -39,12 +38,8 @@ services:
       - "${HOME}/.docker/config.json:/config.json"
     command: --cleanup --interval 7200
 
-  browserless:
-    image: "ghcr.io/browserless/chromium"
+  botasaurus:
+    image: html2rss/botasaurus-scrape-api:latest
     restart: unless-stopped
     ports:
-      - "127.0.0.1:4002:4002"
-    environment:
-      PORT: 4002
-      CONCURRENT: 10
-      TOKEN: ${BROWSERLESS_IO_API_TOKEN:?set BROWSERLESS_IO_API_TOKEN}
+      - "127.0.0.1:4010:4010"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ flowchart TD
     routes --> feeds["Feeds Service (app/web/feeds)"]
     cache["Cache (app/web/feeds/cache.rb)"] --> feeds
     feeds --> gem["html2rss Gem"]
-    strategies["Request Strategies (Faraday / Browserless)"] --> gem
+    strategies["Request Strategies (Faraday / Botasaurus)"] --> gem
     gem --> target["Target Website"]
 ```
 
@@ -55,6 +55,6 @@ The `Html2rss::Web::Feeds::Service` orchestrates extraction behind a gem `FeedRe
 Strategies are defined by the `html2rss` gem but can be configured here.
 
 - **Faraday**: Default HTTP client for static HTML.
-- **Browserless**: Used for JavaScript-heavy websites.
+- **Botasaurus**: Used for JavaScript-heavy websites or anti-bot protected pages (`BOTASAURUS_SCRAPER_URL`).
 
 To add or configure strategies, see `app/web/feeds/source_resolver.rb` and the `html2rss` gem documentation.

--- a/spec/html2rss/web/error_classifier_spec.rb
+++ b/spec/html2rss/web/error_classifier_spec.rb
@@ -67,13 +67,6 @@ RSpec.describe Html2rss::Web::ErrorClassifier do
       expect(described_class.classify(error)).to eq(described_class::SCRAPER_UNAVAILABLE)
     end
 
-    it 'returns the scraper-unavailable decision for BrowserlessConnectionFailed' do
-      stub_const('Html2rss::RequestService::BrowserlessConnectionFailed', Class.new(Html2rss::Error))
-      error = Html2rss::RequestService::BrowserlessConnectionFailed.new('ws closed')
-
-      expect(described_class.classify(error)).to eq(described_class::SCRAPER_UNAVAILABLE)
-    end
-
     it 'returns internal server error decision for unrelated errors' do
       expect(described_class.classify(StandardError.new('boom'))).to eq(described_class::INTERNAL_SERVER_ERROR)
     end

--- a/spec/html2rss/web/feeds/source_resolver_spec.rb
+++ b/spec/html2rss/web/feeds/source_resolver_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Html2rss::Web::Feeds::SourceResolver do
       end
 
       it 'preserves an explicit static strategy when configured' do
-        config[:strategy] = :browserless
+        config[:strategy] = :botasaurus
 
         resolved = described_class.call(feed_request)
 
-        expect(resolved.generator_input[:strategy]).to eq(:browserless)
-        expect(resolved).to have_attributes(url: 'https://example.com/feed', strategy: :browserless)
+        expect(resolved.generator_input[:strategy]).to eq(:botasaurus)
+        expect(resolved).to have_attributes(url: 'https://example.com/feed', strategy: :botasaurus)
       end
     end
 

--- a/spec/html2rss/web/sentry_logs_spec.rb
+++ b/spec/html2rss/web/sentry_logs_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Html2rss::Web::SentryLogs do
       request_id: 'req-123',
       route_group: 'api_v1',
       strategy: 'faraday',
-      details: { url: 'https://example.com/articles', fallback: 'browserless' }
+      details: { url: 'https://example.com/articles', fallback: 'botasaurus' }
     }
   end
 
@@ -132,7 +132,7 @@ RSpec.describe Html2rss::Web::SentryLogs do
   def breadcrumb_details_matcher
     include(
       url: include(host: 'example.com', scheme: 'https'),
-      fallback: 'browserless'
+      fallback: 'botasaurus'
     )
   end
 


### PR DESCRIPTION
This pull request replaces the use of the Browserless service with the Botasaurus service for JavaScript-heavy or anti-bot protected web scraping throughout the codebase, documentation, and tests. The update includes configuration changes, error handling, documentation, and test coverage to ensure consistent use of Botasaurus as the browser automation strategy.

**Service and Configuration Updates:**
- Updated `docker-compose.yml` to remove the `browserless` service and add the `botasaurus` service, including new port and environment variable configuration (`BOTASAURUS_SCRAPER_URL`). [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L24-R24) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L42-R45)

**Documentation Updates:**
- Updated architecture diagrams and documentation to reference Botasaurus instead of Browserless as the browser-based request strategy. [[1]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L14-R14) [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L58-R58)

**Code and Error Handling:**
- Changed display names and error classification logic to use Botasaurus, removing special handling for Browserless connection failures. [[1]](diffhunk://#diff-8d68e1174ec654ada181e0109768e1683a5dda4144ab08edef93f83c87632e8bL37-R37) [[2]](diffhunk://#diff-9a32f6f825abc8eb163c5637a94fa1847e9fc25b8b3bf1335799f5820a7e4890L125-R126)

**Test Updates:**
- Updated tests to reference Botasaurus instead of Browserless in strategy configuration, fallback logic, and error scenarios. [[1]](diffhunk://#diff-cc26d97a911966d98a91c0962fb1989653d90fe3bf87d274e8881cef007141dbL59-R64) [[2]](diffhunk://#diff-afb92bbd54fc569c07e7476c20a3372d09815ec191f8daed35f61d8a58509b55L108-R108) [[3]](diffhunk://#diff-afb92bbd54fc569c07e7476c20a3372d09815ec191f8daed35f61d8a58509b55L135-R135) [[4]](diffhunk://#diff-3b50cfa2f17c0b1ae61c6a8356964b69be531a412590acffee408d71b368cfc6L70-L76)