### PR TITLE
chore(deps): bump html2rss to 0.27.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       net-http (~> 0.5)
     hana (1.3.7)
     hashdiff (1.2.1)
-    html2rss (0.26.0)
+    html2rss (0.27.0)
       addressable (~> 2.7)
       brotli
       dry-validation
@@ -111,7 +111,7 @@ GEM
       faraday-follow_redirects
       faraday-gzip (~> 3)
       kramdown
-      mcp (~> 1.0)
+      mcp (~> 1.2)
       mime-types (> 3.0)
       nokogiri (>= 1.10, < 2.0)
       rack (~> 3.0)
@@ -377,7 +377,7 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  html2rss (0.26.0) sha256=1be3cf38826797b89d453520e84530ee35fd875af79dab1d3010db8a5d2c2457
+  html2rss (0.27.0) sha256=a3b830bb60416627e7a44a39b1cf5aa278a64032750d4a0dbc75482de7535ff1
   html2rss-configs (0.2.0)
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
     rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-openapi (0.33.0)
+    rspec-openapi (0.33.1)
       actionpack (>= 5.2.0)
       rails-dom-testing
       rspec-core
@@ -256,9 +256,9 @@ GEM
     rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-performance (1.26.1)
+    rubocop-performance (1.27.0)
       lint_roller (~> 1.1)
-      rubocop (>= 1.75.0, < 2.0)
+      rubocop (>= 1.89.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
@@ -432,12 +432,12 @@ CHECKSUMS
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
-  rspec-openapi (0.33.0) sha256=58be088d9f8daa567383fcc0b27866b6bd74e3ffff0e48235601a52514853c54
+  rspec-openapi (0.33.1) sha256=8a039893400b8d8fe5c606c2f83d907fc674e74c6c2fcccf0e2dfeff3f5d6fd8
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rss (0.3.3) sha256=37ef1ec4d691d67edbe92159079a4e89a0965e6a6b32246009ae3d734d12d1ab
   rubocop (1.89.0) sha256=4dee8e3ee9c45e474834efd9e8d6fd031e8331c8dacdff0de4ad65ae0a6faae7
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
-  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-performance (1.27.0) sha256=eeeb1374d062a368ee1c787b70eb0b0cc4b184cb1f8565f424760946146d61ce
   rubocop-rake (0.7.1) sha256=3797f2b6810c3e9df7376c26d5f44f3475eda59eb1adc38e6f62ecf027cbae4d
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   rubocop-thread_safety (0.7.3) sha256=067cdd52fbf5deffc18995437e45b5194236eaff4f71de3375a1f6052e48f431


### PR DESCRIPTION
https://github.com/html2rss/html2rss/releases/tag/v0.27.0