### PR TITLE
feat(obs): Sentry ops bridge and separate Botasaurus DSN in compose

### DIFF
--- a/app/web/errors/error_responder.rb
+++ b/app/web/errors/error_responder.rb
@@ -69,13 +69,15 @@ module Html2rss
         end
 
         def emit_error_event(error, decision)
+          diagnostics = ErrorClassifier::Diagnostics.from_error(error)
           details = {
             error_class: error.class.name,
             error_code: decision.code,
             status: decision.status,
-            **ErrorClassifier::Diagnostics.from_error(error).to_h
+            **diagnostics.to_h
           }
           Observability.emit(event_name: 'request.error', outcome: 'failure', level: :error, details: details)
+          SentryOps.emit_operational_failure(decision:, diagnostics:, context: { event_name: 'request.error' })
         end
       end
     end

--- a/app/web/errors/error_responder.rb
+++ b/app/web/errors/error_responder.rb
@@ -70,14 +70,26 @@ module Html2rss
 
         def emit_error_event(error, decision)
           diagnostics = ErrorClassifier::Diagnostics.from_error(error)
-          details = {
+          SentryOps.emit_failure_telemetry(
+            decision:,
+            diagnostics:,
+            event_name: 'request.error',
+            details: error_event_details(error, decision, diagnostics),
+            level: :error
+          )
+        end
+
+        # @param error [StandardError]
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @return [Hash{Symbol=>Object}]
+        def error_event_details(error, decision, diagnostics)
+          {
             error_class: error.class.name,
             error_code: decision.code,
             status: decision.status,
             **diagnostics.to_h
           }
-          Observability.emit(event_name: 'request.error', outcome: 'failure', level: :error, details: details)
-          SentryOps.emit_operational_failure(decision:, diagnostics:, context: { event_name: 'request.error' })
         end
       end
     end

--- a/app/web/feeds/responder.rb
+++ b/app/web/feeds/responder.rb
@@ -81,12 +81,22 @@ module Html2rss
           # @param resolved_source [Html2rss::Web::Feeds::Contracts::ResolvedSource]
           # @param result [Html2rss::Web::Feeds::Contracts::RenderResult]
           # @return [void]
-          def emit_error(target_kind:, identifier:, resolved_source:, result:)
+          # @return [void]
+          def emit_error(target_kind:, identifier:, resolved_source:, result:) # rubocop:disable Metrics/MethodLength
             emit_render_failure(
               target_kind:, identifier:, resolved_source:,
               error_code: result.decision.code,
               error_message: result.error_message || result.client_message,
               **result.diagnostics.to_h
+            )
+            SentryOps.emit_operational_failure(
+              decision: result.decision,
+              diagnostics: result.diagnostics,
+              context: {
+                url: resolved_source.url,
+                strategy: resolved_source.strategy,
+                event_name: 'feed.render'
+              }
             )
           end
 

--- a/app/web/feeds/responder.rb
+++ b/app/web/feeds/responder.rb
@@ -3,11 +3,7 @@
 module Html2rss
   module Web
     module Feeds
-      ##
       # Resolves, renders, and emits feed responses for both token and legacy routes.
-      #
-      # +feed.render+ Observability for completed Service outcomes is emitted only from
-      # {Contracts::RenderResult} fields. +emit_failure+ covers exceptions outside that path.
       module Responder
         class << self
           # @param request [Rack::Request]
@@ -142,8 +138,6 @@ module Html2rss
             reason
           end
 
-          # Emits for exceptions outside a completed RenderResult emit path.
-          #
           # @param target_kind [Symbol]
           # @param identifier [String]
           # @param error [StandardError]

--- a/app/web/feeds/responder.rb
+++ b/app/web/feeds/responder.rb
@@ -81,22 +81,19 @@ module Html2rss
           # @param resolved_source [Html2rss::Web::Feeds::Contracts::ResolvedSource]
           # @param result [Html2rss::Web::Feeds::Contracts::RenderResult]
           # @return [void]
-          # @return [void]
           def emit_error(target_kind:, identifier:, resolved_source:, result:) # rubocop:disable Metrics/MethodLength
-            emit_render_failure(
-              target_kind:, identifier:, resolved_source:,
-              error_code: result.decision.code,
-              error_message: result.error_message || result.client_message,
-              **result.diagnostics.to_h
-            )
-            SentryOps.emit_operational_failure(
+            SentryOps.emit_failure_telemetry(
               decision: result.decision,
               diagnostics: result.diagnostics,
-              context: {
-                url: resolved_source.url,
-                strategy: resolved_source.strategy,
-                event_name: 'feed.render'
-              }
+              event_name: 'feed.render',
+              details: render_details(
+                resolved_source, identifier, target_kind,
+                error_code: result.decision.code,
+                error_message: result.error_message || result.client_message,
+                **result.diagnostics.to_h
+              ),
+              level: :warn,
+              context: { url: resolved_source.url, strategy: resolved_source.strategy }
             )
           end
 
@@ -152,14 +149,30 @@ module Html2rss
           # @param error [StandardError]
           # @return [void]
           def emit_failure(target_kind:, identifier:, error:)
-            details = {
+            decision = ErrorClassifier.classify(error)
+            diagnostics = ErrorClassifier::Diagnostics.from_error(error)
+            SentryOps.emit_failure_telemetry(
+              decision:, diagnostics:, event_name: 'feed.render',
+              details: exception_failure_details(target_kind:, identifier:, error:, decision:, diagnostics:),
+              level: :warn
+            )
+          end
+
+          # @param target_kind [Symbol]
+          # @param identifier [String]
+          # @param error [StandardError]
+          # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+          # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+          # @return [Hash{Symbol=>Object}]
+          def exception_failure_details(target_kind:, identifier:, error:, decision:, diagnostics:)
+            {
               error_class: error.class.name,
               error_message: error.message,
-              **ErrorClassifier::Diagnostics.from_error(error).to_h
-            }
-            details[:feed_name] = identifier if target_kind == :static
-
-            Observability.emit(event_name: 'feed.render', outcome: 'failure', details:, level: :warn)
+              error_code: decision.code,
+              **diagnostics.to_h
+            }.tap do |details|
+              details[:feed_name] = identifier if target_kind == :static
+            end
           end
         end
       end

--- a/app/web/telemetry/sentry_ops.rb
+++ b/app/web/telemetry/sentry_ops.rb
@@ -20,6 +20,22 @@ module Html2rss
       SERVICE_NAME = 'html2rss-web'
 
       class << self
+        # Emits product telemetry and, when applicable, a P0 Sentry Issue.
+        #
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @param event_name [String]
+        # @param details [Hash{Symbol=>Object}]
+        # @param level [Symbol]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [void]
+        def emit_failure_telemetry(decision:, diagnostics:, event_name:, details:, level: :error, context: {}) # rubocop:disable Metrics/ParameterLists
+          Observability.emit(event_name:, outcome: 'failure', level:, details:)
+          emit_operational_failure(decision:, diagnostics:, context: context.merge(event_name:))
+        rescue StandardError
+          nil
+        end
+
         # @param decision [Html2rss::Web::ErrorClassifier::Decision]
         # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
         # @param context [Hash{Symbol=>Object}]

--- a/app/web/telemetry/sentry_ops.rb
+++ b/app/web/telemetry/sentry_ops.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'html2rss/url'
+
+module Html2rss
+  module Web
+    ##
+    # Emits P0 operational failures to Sentry Issues.
+    #
+    # Distinct from {SentryLogs}, which mirrors structured stdout logs when
+    # +SENTRY_ENABLE_LOGS=true+. This module consumes {ErrorClassifier::Decision}
+    # codes only — it never re-classifies exceptions.
+    module SentryOps
+      OPERATIONAL_CODES = %w[
+        SCRAPER_UNAVAILABLE
+        GATEWAY_TIMEOUT
+        INTERNAL_SERVER_ERROR
+        SERVICE_UNAVAILABLE
+      ].freeze
+      SERVICE_NAME = 'html2rss-web'
+
+      class << self
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [void]
+        def emit_operational_failure(decision:, diagnostics:, context: {})
+          return unless operational_code?(decision.code)
+          return unless sentry_ready?
+
+          capture_operational_failure(decision, diagnostics, context)
+        rescue StandardError
+          nil
+        end
+
+        private
+
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [void]
+        def capture_operational_failure(decision, diagnostics, context)
+          ::Sentry.capture_message(
+            operational_message(decision, context),
+            level: :error,
+            tags: sentry_tags(decision, diagnostics, context),
+            fingerprint: sentry_fingerprint(diagnostics, context),
+            extra: sentry_extra(diagnostics, context)
+          )
+        end
+
+        # @param code [String]
+        # @return [Boolean]
+        def operational_code?(code)
+          OPERATIONAL_CODES.include?(code.to_s)
+        end
+
+        # @return [Boolean]
+        def sentry_ready?
+          RuntimeEnv.sentry_enabled? &&
+            defined?(::Sentry) &&
+            ::Sentry.respond_to?(:capture_message)
+        end
+
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [String]
+        def operational_message(decision, context)
+          event = context[:event_name] || 'operational.failure'
+          "#{event}: #{decision.code}"
+        end
+
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [Hash{Symbol=>Object}]
+        def sentry_tags(decision, diagnostics, context)
+          {
+            error_code: decision.code,
+            error_category: diagnostics.error_category,
+            request_id: diagnostics.request_id,
+            strategy: context[:strategy],
+            strategy_used: diagnostics.strategy_used,
+            host: hostname(context[:url]),
+            render_ms: diagnostics.render_ms
+          }.compact
+        end
+
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [Array<String>]
+        def sentry_fingerprint(diagnostics, context)
+          [
+            SERVICE_NAME,
+            diagnostics.error_category || 'unknown',
+            hostname(context[:url]) || 'unknown-host'
+          ]
+        end
+
+        # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
+        # @param context [Hash{Symbol=>Object}]
+        # @return [Hash{Symbol=>Object}]
+        def sentry_extra(diagnostics, context)
+          extras = {}
+          extras[:event_name] = context[:event_name] if context[:event_name]
+          extras[:request_id] = diagnostics.request_id if diagnostics.request_id
+          extras
+        end
+
+        # @param url [Object]
+        # @return [String, nil]
+        def hostname(url)
+          return if url.to_s.empty?
+
+          Html2rss::Url.for_channel(url.to_s).host
+        rescue StandardError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/web/telemetry/sentry_ops.rb
+++ b/app/web/telemetry/sentry_ops.rb
@@ -7,9 +7,8 @@ module Html2rss
     ##
     # Emits P0 operational failures to Sentry Issues.
     #
-    # Distinct from {SentryLogs}, which mirrors structured stdout logs when
-    # +SENTRY_ENABLE_LOGS=true+. This module consumes {ErrorClassifier::Decision}
-    # codes only — it never re-classifies exceptions.
+    # Separate from {SentryLogs} (opt-in via +SENTRY_ENABLE_LOGS+). Uses
+    # {ErrorClassifier::Decision} codes only.
     module SentryOps
       OPERATIONAL_CODES = %w[
         SCRAPER_UNAVAILABLE
@@ -20,8 +19,6 @@ module Html2rss
       SERVICE_NAME = 'html2rss-web'
 
       class << self
-        # Emits product telemetry and, when applicable, a P0 Sentry Issue.
-        #
         # @param decision [Html2rss::Web::ErrorClassifier::Decision]
         # @param diagnostics [Html2rss::Web::ErrorClassifier::Diagnostics]
         # @param event_name [String]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       GIT_SHA: ${GIT_SHA:-local}
       HTML2RSS_SECRET_KEY: ${HTML2RSS_SECRET_KEY:?set HTML2RSS_SECRET_KEY}
       HEALTH_CHECK_TOKEN: ${HEALTH_CHECK_TOKEN:?set HEALTH_CHECK_TOKEN}
+      # Sentry Project A (html2rss-web): Issues via SentryOps + Rack middleware.
+      # Structured log intake stays opt-in — set SENTRY_ENABLE_LOGS=true explicitly.
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENABLE_LOGS: ${SENTRY_ENABLE_LOGS:-false}
       HTML2RSS_TOTAL_TIMEOUT_SECONDS: 25
@@ -41,5 +43,10 @@ services:
   botasaurus:
     image: html2rss/botasaurus-scrape-api:latest
     restart: unless-stopped
+    environment:
+      # Sentry Project B (botasaurus-scrape-api): use BOTASAURUS_SENTRY_DSN only — never web SENTRY_DSN.
+      SENTRY_DSN: ${BOTASAURUS_SENTRY_DSN:?set BOTASAURUS_SENTRY_DSN}
+      SENTRY_ENVIRONMENT: ${ENVIRONMENT:-production}
+      SENTRY_RELEASE: ${GIT_SHA:-unknown}
     ports:
       - "127.0.0.1:4010:4010"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ services:
       GIT_SHA: ${GIT_SHA:-local}
       HTML2RSS_SECRET_KEY: ${HTML2RSS_SECRET_KEY:?set HTML2RSS_SECRET_KEY}
       HEALTH_CHECK_TOKEN: ${HEALTH_CHECK_TOKEN:?set HEALTH_CHECK_TOKEN}
-      # Sentry Project A (html2rss-web): Issues via SentryOps + Rack middleware.
-      # Structured log intake stays opt-in — set SENTRY_ENABLE_LOGS=true explicitly.
+      # Web Sentry (Project A): SENTRY_DSN; logs opt-in via SENTRY_ENABLE_LOGS=true
       SENTRY_DSN: ${SENTRY_DSN:-}
       SENTRY_ENABLE_LOGS: ${SENTRY_ENABLE_LOGS:-false}
       HTML2RSS_TOTAL_TIMEOUT_SECONDS: 25
@@ -44,7 +43,7 @@ services:
     image: html2rss/botasaurus-scrape-api:latest
     restart: unless-stopped
     environment:
-      # Sentry Project B (botasaurus-scrape-api): use BOTASAURUS_SENTRY_DSN only — never web SENTRY_DSN.
+      # Scraper Sentry (Project B): BOTASAURUS_SENTRY_DSN only — not web SENTRY_DSN
       SENTRY_DSN: ${BOTASAURUS_SENTRY_DSN:?set BOTASAURUS_SENTRY_DSN}
       SENTRY_ENVIRONMENT: ${ENVIRONMENT:-production}
       SENTRY_RELEASE: ${GIT_SHA:-unknown}

--- a/docs/README.md
+++ b/docs/README.md
@@ -217,63 +217,55 @@ Critical-path event families: auth, feed create, feed render, request errors.
 
 ### Sentry DSN separation
 
-Use **separate Sentry projects** for each service. Never share a DSN between html2rss-web and botasaurus-scrape-api.
+Use separate Sentry projects for html2rss-web and botasaurus-scrape-api. Never share a DSN.
 
-| Env var | Service | Sentry project |
+| Env var | Service | Project |
 | --- | --- | --- |
-| `SENTRY_DSN` | html2rss-web | Project A (web) |
-| `BOTASAURUS_SENTRY_DSN` | botasaurus-scrape-api | Project B (scraper) |
+| `SENTRY_DSN` | html2rss-web | A (web) |
+| `BOTASAURUS_SENTRY_DSN` | botasaurus-scrape-api | B (scraper) |
 
-`docker-compose.yml` requires `BOTASAURUS_SENTRY_DSN` for the botasaurus service and does **not** fall back to web `SENTRY_DSN`.
+Compose requires `BOTASAURUS_SENTRY_DSN` for botasaurus and does not fall back to web `SENTRY_DSN`.
 
 ## Sentry Runbook
 
-When `SENTRY_DSN` is present, Sentry Issues are enabled for html2rss-web via Rack middleware and `Telemetry::SentryOps` (P0 operational codes only). `BUILD_TAG` and `GIT_SHA` become the release identifier, and `RACK_ENV` becomes the environment tag.
+With `SENTRY_DSN` set, html2rss-web sends unhandled exceptions (Rack middleware) and P0 operational failures (`SentryOps`) to Sentry Issues. Release is `BUILD_TAG+GIT_SHA`; environment is `RACK_ENV`.
 
-Structured log intake into Sentry is **opt-in**: set `SENTRY_ENABLE_LOGS=true` explicitly. A DSN alone does not enable log forwarding (`SentryLogs`).
+Structured log intake is opt-in: set `SENTRY_ENABLE_LOGS=true`. A DSN alone does not enable `SentryLogs`.
 
-Triage starts with the newest `feed.create`, `feed.render`, and `request.error` events. Confirm the release tag, route group, strategy, and outcome before deciding whether the failure is retryable, terminal, or user-facing.
+Start triage from the newest `feed.create`, `feed.render`, and `request.error` events. Check release, route group, strategy, and outcome.
 
 ### On-call triage
 
-1. **Confirm the project** — check env vars first (`SENTRY_DSN` vs `BOTASAURUS_SENTRY_DSN`). A scraper outage in the web project usually means DSN mix-up.
-2. **Correlate across services** — open the Sentry issue, copy the `request_id` tag, then search the other project for the same `request_id`.
+1. **Confirm project** — `SENTRY_DSN` (web) vs `BOTASAURUS_SENTRY_DSN` (scraper). Scraper errors in the web project usually mean DSN mix-up.
+2. **Correlate** — copy `request_id` from one issue and search the other project.
 3. **Decision tree**
-   - `SCRAPER_UNAVAILABLE` / botasaurus `navigation_error` → scraper connectivity or upstream crash
-   - `challenge_block` metric (botasaurus) or web `BLOCKED_SURFACE` → target site blocked automation (product signal, no page)
-   - `EXTRACTION_EMPTY` → config/selectors issue (product signal, no page)
-   - `GATEWAY_TIMEOUT` / `timeout` → slow or unreachable target host
+   - `SCRAPER_UNAVAILABLE` / `navigation_error` → scraper down or unreachable
+   - `challenge_block` (scraper) or `BLOCKED_SURFACE` (web) → site blocked automation (product signal)
+   - `EXTRACTION_EMPTY` → selectors/config (product signal)
+   - `GATEWAY_TIMEOUT` / `timeout` → slow or unreachable target
 
-### Alert baselines (Sentry UI)
+### Alert baselines
 
-Configure these in each project after baseline traffic is established:
+After baseline traffic, configure per project:
 
-**Project B — botasaurus-scrape-api**
+**Project B (scraper)**
 
-- P0 Issue alert: `error_category:navigation_error` rate above baseline
-- P0 Issue alert: `error_category:timeout` sustained spike
-- Metric alert: `scrape.challenge_block` rate anomaly (product signal — no page)
+- P0: `error_category:navigation_error` above baseline
+- P0: `error_category:timeout` sustained spike
+- Metric: `scrape.challenge_block` anomaly (product signal)
 
-**Project A — html2rss-web**
+**Project A (web)**
 
-- P0 Issue alert: `error_code:SCRAPER_UNAVAILABLE` any sustained occurrence
-- P0 Issue alert: `request.error` spike with `kind:server`
+- P0: `error_code:SCRAPER_UNAVAILABLE` sustained
+- P0: `request.error` spike with `kind:server`
 
-### Dashboard baselines (Sentry UI)
+### Dashboard baselines
 
-**Scraper (Project B)**
+**Scraper (B)**: outcomes by `error_category`, top `host`, `render_ms`, `scrape.challenge_block` trend
 
-- Outcomes by `error_category`
-- Top `host` values
-- `render_ms` distribution
-- `scrape.challenge_block` metric trend
+**Web (A)**: `feed.render` failures by `error_code`/`strategy`, release comparison
 
-**Web (Project A)**
-
-- `feed.render` failures by `error_code` and `strategy`
-- Release comparison for operational issue volume
-
-Alert on sustained production `request.error` spikes or repeated `feed.render` failures, then tune thresholds from real incidents.
+Tune alert thresholds from sustained `request.error` or `feed.render` failure spikes.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -215,16 +215,65 @@ Canonical event fields: `event_name`, `schema_version`, `request_id`, `route_gro
 
 Critical-path event families: auth, feed create, feed render, request errors.
 
+### Sentry DSN separation
+
+Use **separate Sentry projects** for each service. Never share a DSN between html2rss-web and botasaurus-scrape-api.
+
+| Env var | Service | Sentry project |
+| --- | --- | --- |
+| `SENTRY_DSN` | html2rss-web | Project A (web) |
+| `BOTASAURUS_SENTRY_DSN` | botasaurus-scrape-api | Project B (scraper) |
+
+`docker-compose.yml` requires `BOTASAURUS_SENTRY_DSN` for the botasaurus service and does **not** fall back to web `SENTRY_DSN`.
+
 ## Sentry Runbook
 
-When `SENTRY_DSN` is present, Sentry is enabled. `BUILD_TAG` and `GIT_SHA` become the release identifier, and
-`RACK_ENV` becomes the environment tag.
+When `SENTRY_DSN` is present, Sentry Issues are enabled for html2rss-web via Rack middleware and `Telemetry::SentryOps` (P0 operational codes only). `BUILD_TAG` and `GIT_SHA` become the release identifier, and `RACK_ENV` becomes the environment tag.
 
-Triage starts with the newest `feed.create`, `feed.render`, and `request.error` events. Confirm the release tag,
-route group, strategy, and outcome before deciding whether the failure is retryable, terminal, or user-facing.
+Structured log intake into Sentry is **opt-in**: set `SENTRY_ENABLE_LOGS=true` explicitly. A DSN alone does not enable log forwarding (`SentryLogs`).
 
-Alert on sustained production `request.error` spikes or repeated `feed.render` failures, then tune thresholds from
-real incidents.
+Triage starts with the newest `feed.create`, `feed.render`, and `request.error` events. Confirm the release tag, route group, strategy, and outcome before deciding whether the failure is retryable, terminal, or user-facing.
+
+### On-call triage
+
+1. **Confirm the project** — check env vars first (`SENTRY_DSN` vs `BOTASAURUS_SENTRY_DSN`). A scraper outage in the web project usually means DSN mix-up.
+2. **Correlate across services** — open the Sentry issue, copy the `request_id` tag, then search the other project for the same `request_id`.
+3. **Decision tree**
+   - `SCRAPER_UNAVAILABLE` / botasaurus `navigation_error` → scraper connectivity or upstream crash
+   - `challenge_block` metric (botasaurus) or web `BLOCKED_SURFACE` → target site blocked automation (product signal, no page)
+   - `EXTRACTION_EMPTY` → config/selectors issue (product signal, no page)
+   - `GATEWAY_TIMEOUT` / `timeout` → slow or unreachable target host
+
+### Alert baselines (Sentry UI)
+
+Configure these in each project after baseline traffic is established:
+
+**Project B — botasaurus-scrape-api**
+
+- P0 Issue alert: `error_category:navigation_error` rate above baseline
+- P0 Issue alert: `error_category:timeout` sustained spike
+- Metric alert: `scrape.challenge_block` rate anomaly (product signal — no page)
+
+**Project A — html2rss-web**
+
+- P0 Issue alert: `error_code:SCRAPER_UNAVAILABLE` any sustained occurrence
+- P0 Issue alert: `request.error` spike with `kind:server`
+
+### Dashboard baselines (Sentry UI)
+
+**Scraper (Project B)**
+
+- Outcomes by `error_category`
+- Top `host` values
+- `render_ms` distribution
+- `scrape.challenge_block` metric trend
+
+**Web (Project A)**
+
+- `feed.render` failures by `error_code` and `strategy`
+- Release comparison for operational issue volume
+
+Alert on sustained production `request.error` spikes or repeated `feed.render` failures, then tune thresholds from real incidents.
 
 ---
 

--- a/spec/html2rss/web/feeds/responder_spec.rb
+++ b/spec/html2rss/web/feeds/responder_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Html2rss::Web::Feeds::Responder do
   before do
     allow(Html2rss::Web::LocalConfig).to receive(:find).with('example').and_return(static_config)
     allow(Html2rss::Web::Observability).to receive(:emit)
+    allow(Html2rss::Web::SentryOps).to receive(:emit_failure_telemetry)
   end
 
   context 'with a cacheable success result' do
@@ -147,9 +148,10 @@ RSpec.describe Html2rss::Web::Feeds::Responder do
 
       write_response
 
-      expect(Html2rss::Web::Observability).to have_received(:emit).with(
+      expect(Html2rss::Web::SentryOps).to have_received(:emit_failure_telemetry).with(
+        decision: Html2rss::Web::ErrorClassifier::INTERNAL_SERVER_ERROR,
+        diagnostics: have_attributes(strategy_attempts: attempts),
         event_name: 'feed.render',
-        outcome: 'failure',
         details: include(
           strategy: :faraday,
           url: 'https://example.com',
@@ -158,7 +160,8 @@ RSpec.describe Html2rss::Web::Feeds::Responder do
           error_message: 'timeout',
           strategy_attempts: attempts
         ),
-        level: :warn
+        level: :warn,
+        context: { url: 'https://example.com', strategy: :faraday }
       )
     end
   end
@@ -276,13 +279,19 @@ RSpec.describe Html2rss::Web::Feeds::Responder do
       allow(Html2rss::Web::Feeds::Renderer).to receive(:render).and_raise(StandardError, 'render failed')
     end
 
-    it 'emits only the failure event' do
+    it 'emits only the failure event' do # rubocop:disable RSpec/ExampleLength
       expect { write_response }.to raise_error(StandardError, 'render failed')
 
-      expect(Html2rss::Web::Observability).to have_received(:emit).once.with(
+      expect(Html2rss::Web::SentryOps).to have_received(:emit_failure_telemetry).once.with(
+        decision: Html2rss::Web::ErrorClassifier::INTERNAL_SERVER_ERROR,
+        diagnostics: Html2rss::Web::ErrorClassifier::Diagnostics.empty,
         event_name: 'feed.render',
-        outcome: 'failure',
-        details: include(error_class: 'StandardError', error_message: 'render failed', feed_name: 'example'),
+        details: include(
+          error_class: 'StandardError',
+          error_message: 'render failed',
+          error_code: 'INTERNAL_SERVER_ERROR',
+          feed_name: 'example'
+        ),
         level: :warn
       )
     end

--- a/spec/html2rss/web/sentry_logs_spec.rb
+++ b/spec/html2rss/web/sentry_logs_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Html2rss::Web::SentryLogs do
     expect(captured_call).to eq({})
   end
 
+  it 'keeps log intake disabled when only SENTRY_DSN is set', :aggregate_failures do
+    stub_const('Sentry', fake_sentry)
+    allow(Html2rss::Web::RuntimeEnv).to receive_messages(sentry_enabled?: true, sentry_logs_enabled?: false)
+    expect(described_class.send(:enabled?)).to be(false)
+
+    described_class.emit(raw_payload)
+
+    expect(captured_call).to eq({})
+  end
+
   it 'does not forward payloads when sentry is disabled' do
     stub_const('Sentry', fake_sentry)
     allow(Html2rss::Web::RuntimeEnv).to receive_messages(sentry_enabled?: false, sentry_logs_enabled?: true)

--- a/spec/html2rss/web/sentry_ops_spec.rb
+++ b/spec/html2rss/web/sentry_ops_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative '../../../app/web/config/runtime_env'
+require_relative '../../../app/web/errors/error_classifier'
+require_relative '../../../app/web/telemetry/sentry_ops'
+
+RSpec.describe Html2rss::Web::SentryOps do
+  let(:capture_store) { {} }
+  let(:diagnostics) do
+    Html2rss::Web::ErrorClassifier::Diagnostics.new(
+      strategy_attempts: [],
+      request_id: 'req-scrape-42',
+      strategy_used: 'botasaurus',
+      render_ms: 12_345,
+      error_category: 'timeout'
+    )
+  end
+  let(:context) do
+    {
+      event_name: 'feed.render',
+      url: 'https://news.example.com/articles',
+      strategy: :botasaurus
+    }
+  end
+
+  before do
+    store = capture_store
+    fake_sentry = Module.new
+    fake_sentry.define_singleton_method(:capture_message) do |message, **kwargs|
+      store.merge!(message:, **kwargs)
+    end
+    stub_const('Sentry', fake_sentry)
+    allow(Html2rss::Web::RuntimeEnv).to receive(:sentry_enabled?).and_return(true)
+  end
+
+  Html2rss::Web::SentryOps::OPERATIONAL_CODES.each do |code|
+    it "emits a Sentry issue for operational code #{code}", :aggregate_failures do
+      described_class.emit_operational_failure(
+        decision: operational_decision(code),
+        diagnostics:,
+        context:
+      )
+
+      expect(capture_store).to include(expected_capture_for(code))
+    end
+  end
+
+  %w[BLOCKED_SURFACE EXTRACTION_EMPTY].each do |code|
+    it "does not emit a Sentry issue for product-signal code #{code}" do
+      described_class.emit_operational_failure(
+        decision: Html2rss::Web::ErrorClassifier.const_get(code),
+        diagnostics:,
+        context:
+      )
+
+      expect(capture_store).to be_empty
+    end
+  end
+
+  it 'does not emit when Sentry is disabled' do
+    allow(Html2rss::Web::RuntimeEnv).to receive(:sentry_enabled?).and_return(false)
+
+    described_class.emit_operational_failure(
+      decision: operational_decision('SCRAPER_UNAVAILABLE'),
+      diagnostics:,
+      context:
+    )
+
+    expect(capture_store).to be_empty
+  end
+
+  def operational_decision(code)
+    Html2rss::Web::ErrorClassifier.const_get(code)
+  end
+
+  def expected_capture_for(code) # rubocop:disable Metrics/MethodLength
+    {
+      message: "feed.render: #{code}",
+      level: :error,
+      tags: include(
+        error_code: code,
+        error_category: 'timeout',
+        request_id: 'req-scrape-42',
+        strategy: :botasaurus,
+        strategy_used: 'botasaurus',
+        host: 'news.example.com',
+        render_ms: 12_345
+      ),
+      fingerprint: ['html2rss-web', 'timeout', 'news.example.com'],
+      extra: include(event_name: 'feed.render', request_id: 'req-scrape-42')
+    }
+  end
+end

--- a/spec/html2rss/web/sentry_ops_spec.rb
+++ b/spec/html2rss/web/sentry_ops_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 require_relative '../../../app/web/config/runtime_env'
 require_relative '../../../app/web/errors/error_classifier'
+require_relative '../../../app/web/telemetry/observability'
 require_relative '../../../app/web/telemetry/sentry_ops'
 
 RSpec.describe Html2rss::Web::SentryOps do
@@ -69,6 +70,26 @@ RSpec.describe Html2rss::Web::SentryOps do
     )
 
     expect(capture_store).to be_empty
+  end
+
+  it 'emits observability and sentry for classified failures', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(Html2rss::Web::Observability).to receive(:emit)
+
+    described_class.emit_failure_telemetry(
+      decision: operational_decision('SERVICE_UNAVAILABLE'),
+      diagnostics:,
+      event_name: 'request.error',
+      details: { error_code: 'SERVICE_UNAVAILABLE', status: 503 },
+      level: :error
+    )
+
+    expect(Html2rss::Web::Observability).to have_received(:emit).with(
+      event_name: 'request.error',
+      outcome: 'failure',
+      level: :error,
+      details: { error_code: 'SERVICE_UNAVAILABLE', status: 503 }
+    )
+    expect(capture_store).to include(message: 'request.error: SERVICE_UNAVAILABLE')
   end
 
   def operational_decision(code)


### PR DESCRIPTION
## Summary

- Require `BOTASAURUS_SENTRY_DSN` for botasaurus in compose (no web `SENTRY_DSN` fallback).
- Add `SentryOps` to emit P0 operational failures to Sentry with `request_id` correlation.
- Route classified failures through one telemetry bridge in feed/error responders.
- Expand Sentry runbook: DSN separation, on-call triage, alert/dashboard baselines.

## Test plan

- [x] `bundle exec rspec spec/html2rss/web/sentry_ops_spec.rb spec/html2rss/web/sentry_logs_spec.rb spec/html2rss/web/error_responder_spec.rb spec/html2rss/web/feeds/responder_spec.rb`
- [ ] Smoke: distinct DSNs per service, trigger scrape failure, confirm correlated issues in both projects

## Deploy note

Coordinate with [botasaurus-scrape-api#39](https://github.com/html2rss/botasaurus-scrape-api/pull/39) for scraper-side Sentry wiring.