### PR TITLE
fix(web): map RequestTimedOut to GATEWAY_TIMEOUT

### DIFF
--- a/app/web/errors/error_classifier.rb
+++ b/app/web/errors/error_classifier.rb
@@ -213,6 +213,11 @@ module Html2rss
            defined?(::Html2rss::RequestService::BotasaurusConnectionFailed) &&
              c.any?(::Html2rss::RequestService::BotasaurusConnectionFailed)
          }, SCRAPER_UNAVAILABLE],
+        [lambda { |c, _|
+           # Gem wall-clock timeout (Botasaurus 504 / Faraday timeout) — not Timeout::Error.
+           defined?(::Html2rss::RequestService::RequestTimedOut) &&
+             c.any?(::Html2rss::RequestService::RequestTimedOut)
+         }, GATEWAY_TIMEOUT],
         [lambda { |_, err|
            defined?(::Rack::Timeout::RequestTimeoutException) && err.is_a?(::Rack::Timeout::RequestTimeoutException)
          }, SERVICE_UNAVAILABLE],

--- a/spec/html2rss/web/error_classifier_spec.rb
+++ b/spec/html2rss/web/error_classifier_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe Html2rss::Web::ErrorClassifier do
       expect(described_class.classify(error)).to eq(described_class::SCRAPER_UNAVAILABLE)
     end
 
+    it 'returns gateway timeout for RequestTimedOut (Botasaurus/Faraday wall-clock)' do
+      stub_const('Html2rss::RequestService::RequestTimedOut', Class.new(Html2rss::Error))
+      error = Html2rss::RequestService::RequestTimedOut.new('Botasaurus scrape timed out')
+
+      expect(described_class.classify(error)).to eq(described_class::GATEWAY_TIMEOUT)
+    end
+
+    it 'detects RequestTimedOut through Exception#cause' do
+      stub_const('Html2rss::RequestService::RequestTimedOut', Class.new(Html2rss::Error))
+      root = Html2rss::RequestService::RequestTimedOut.new('timed out')
+      wrapped = StandardError.new('wrapped')
+      allow(wrapped).to receive(:cause).and_return(root)
+
+      expect(described_class.classify(wrapped)).to eq(described_class::GATEWAY_TIMEOUT)
+    end
+
     it 'returns internal server error decision for unrelated errors' do
       expect(described_class.classify(StandardError.new('boom'))).to eq(described_class::INTERNAL_SERVER_ERROR)
     end


### PR DESCRIPTION
## What changed

- `ErrorClassifier` maps `Html2rss::RequestService::RequestTimedOut` (cause-chain aware) to `GATEWAY_TIMEOUT` (504), same pattern as `BotasaurusConnectionFailed`.
- Specs cover direct raise and wrapped `Exception#cause`.

## Why

### Root cause

Botasaurus scrape 504s raise gem `RequestTimedOut` (`< Html2rss::Error`), which is not `Timeout::Error`. The classifier only treated stdlib timeouts as 504, so feed renders became `INTERNAL_SERVER_ERROR` (500) and noisy `feed.render` Sentry events (e.g. H2R-WEB-25).

## Risk

- Low — HTTP status remapping only; `ErrorResponder` already sets `Retry-After` for 504.
- `:auto` paths that end in `NoFeedItemsExtracted` are unchanged.

## Review map

Review map: whole PR is small — start at `app/web/errors/error_classifier.rb`.

## Validation

- `mise exec -- bundle exec rspec spec/html2rss/web/error_classifier_spec.rb spec/html2rss/web/error_responder_spec.rb` — 28 examples, 0 failures
- Assure (`review.gil` findings): production readiness Yes; no P0/P1