### PR TITLE
feat(api): adopt scraped site_title from FeedResult on feed creation

### DIFF
--- a/app/web/api/v1/create_feed.rb
+++ b/app/web/api/v1/create_feed.rb
@@ -45,8 +45,11 @@ module Html2rss
             end
 
             def build_create_params(request, account)
-              url = validated_url(request_params(request)['url'], account)
-              FeedMetadata::CreateParams.new(url:, name: Feeds::ChannelTitle.for(url))
+              params = request_params(request)
+              url = validated_url(params['url'], account)
+              name = params['name'].to_s.strip
+              name = nil if name.empty?
+              FeedMetadata::CreateParams.new(url:, name:)
             end
 
             def request_params(request)
@@ -109,8 +112,23 @@ module Html2rss
               feed_token = Auth.generate_feed_token(account[:username], params.url)
               raise Html2rss::Web::InternalServerError, 'Failed to create feed' unless feed_token
 
-              ensure_extractable!(Feeds::Service.call(resolved_source_for(feed_token)))
-              FeedMetadata.build(account:, name: params.name, url: params.url, feed_token:)
+              result = Feeds::Service.call(resolved_source_for(feed_token))
+              ensure_extractable!(result)
+              name = resolve_feed_name(params.name, result, params.url)
+              FeedMetadata.build(account:, name:, url: params.url, feed_token:)
+            end
+
+            # @param requested_name [String, nil]
+            # @param result [Html2rss::Web::Feeds::Contracts::RenderResult]
+            # @param url [String]
+            # @return [String]
+            def resolve_feed_name(requested_name, result, url)
+              return requested_name unless requested_name.to_s.empty?
+
+              site_title = result.payload&.site_title
+              return site_title unless site_title.to_s.empty?
+
+              Feeds::ChannelTitle.for(url) || url.to_s
             end
 
             # @param feed_token [String]

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -149,6 +149,7 @@ export type OptionsConfigCatalogResponse = OptionsConfigCatalogResponses[keyof O
 
 export type CreateFeedData = {
     body?: {
+        name?: string;
         url: string;
     };
     headers: {

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -321,6 +321,8 @@ paths:
           application/json:
             schema:
               properties:
+                name:
+                  type: string
                 url:
                   type: string
               required:

--- a/spec/html2rss/web/api/v1_spec.rb
+++ b/spec/html2rss/web/api/v1_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     )
   end
 
+  def feed_result_with_site_title(site_title)
+    Html2rss::Web::Feeds::Contracts::RenderResult.new(
+      status: :ok,
+      payload: Html2rss::Web::Feeds::Contracts::RenderPayload.new(feed: nil, site_title:, url: feed_url),
+      ttl_seconds: 600,
+      cache_key: 'feed_result:with-title'
+    )
+  end
+
   def service_error_result
     Html2rss::Web::Feeds::Contracts::RenderResult.new(
       status: :error,
@@ -730,6 +739,28 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
       expect_feed_payload(json)
       expect(json.fetch('data')).not_to have_key('conversion')
       expect(last_response.headers['Content-Type']).to include('application/json')
+    end
+
+    it 'adopts scraped site_title from Service execution when available', :aggregate_failures do
+      allow(Html2rss::Web::Feeds::Service).to receive(:call)
+        .and_return(feed_result_with_site_title('Live Scraped Site Title'))
+
+      post_feed_request(url: feed_url)
+
+      expect(last_response.status).to eq(201)
+      json = expect_success_response(last_response)
+      expect(json.dig('data', 'feed', 'name')).to eq('Live Scraped Site Title')
+    end
+
+    it 'prefers explicit requested name over scraped site_title', :aggregate_failures do
+      allow(Html2rss::Web::Feeds::Service).to receive(:call)
+        .and_return(feed_result_with_site_title('Live Scraped Site Title'))
+
+      post_feed_request(url: feed_url, name: 'My Custom Feed Name')
+
+      expect(last_response.status).to eq(201)
+      json = expect_success_response(last_response)
+      expect(json.dig('data', 'feed', 'name')).to eq('My Custom Feed Name')
     end
 
     it 'normalizes hostname-only input to https before feed creation', :aggregate_failures do


### PR DESCRIPTION
## Summary
When creating a feed via `POST /api/v1/feeds`, `CreateFeed` executes create-time extraction via `Feeds::Service` to ensure extractability and warm the cache.

Previously, `CreateFeed` assigned the feed `name` using static domain heuristics (`ChannelTitle.for(url)`), ignoring the live title extracted during the scrape.

This change:
- Resolves feed `name` by preferring:
  1. Explicitly requested `name` (if provided in payload)
  2. Live `site_title` from `RenderPayload` / `FeedResult` (`feed_result.channel_title`)
  3. Static fallback (`ChannelTitle.for(url)` / `url.to_s`)
- Updates OpenAPI spec snapshot and generated frontend client types to document the optional `name` attribute on feed create requests.

## Validation
- `make ready` passed in Dev Container (340 examples, 0 failures, RuboCop, Zeitwerk, YARD docs check).
- `make openapi-verify` passed in Dev Container.
- `make ci-ready` passed in Dev Container (including Playwright frontend e2e smoke).