### PR TITLE
fix(telemetry): prune GATEWAY_TIMEOUT from Sentry operational failures

### DIFF
--- a/app/web/telemetry/sentry_ops.rb
+++ b/app/web/telemetry/sentry_ops.rb
@@ -11,9 +11,8 @@ module Html2rss
     # {ErrorClassifier::Decision} codes only.
     module SentryOps
       OPERATIONAL_CODES = %w[
-        SCRAPER_UNAVAILABLE
-        GATEWAY_TIMEOUT
         INTERNAL_SERVER_ERROR
+        SCRAPER_UNAVAILABLE
         SERVICE_UNAVAILABLE
       ].freeze
       SERVICE_NAME = 'html2rss-web'

--- a/docs/README.md
+++ b/docs/README.md
@@ -243,7 +243,7 @@ When triaging `GATEWAY_TIMEOUT`, capacity-shaped `SERVICE_UNAVAILABLE` (queue/bo
 
 ## Sentry Runbook
 
-With `SENTRY_DSN` set, html2rss-web sends unhandled exceptions (Rack middleware) and P0 operational failures (`SentryOps`) to Sentry Issues. Release is `BUILD_TAG+GIT_SHA`; environment is `RACK_ENV`.
+With `SENTRY_DSN` set, html2rss-web sends unhandled exceptions (Rack middleware) and P0 operational server failures (`SentryOps`: `SCRAPER_UNAVAILABLE`, `SERVICE_UNAVAILABLE`, `INTERNAL_SERVER_ERROR`) to Sentry Issues. Transient target timeouts (`GATEWAY_TIMEOUT`) and extraction warnings stay in structured stdout logs (`feed.render` / `request.error`) and Sentry breadcrumbs to prevent alert fatigue from slow external websites. Release is `BUILD_TAG+GIT_SHA`; environment is `RACK_ENV`.
 
 Structured log intake is opt-in: set `SENTRY_ENABLE_LOGS=true`. A DSN alone does not enable `SentryLogs`.
 
@@ -276,7 +276,7 @@ After baseline traffic, configure per project:
 
 - P0: `error_code:SCRAPER_UNAVAILABLE` sustained
 - P0: `error_code:SERVICE_UNAVAILABLE` sustained when correlated with scraper queue/boot timeouts (capacity)
-- P1: `error_code:GATEWAY_TIMEOUT` sustained (slow targets / ladder mismatch) — do not conflate with capacity
+- Metric / Log: `error_code:GATEWAY_TIMEOUT` rate (slow targets / ladder mismatch; monitored via structured logs, not Sentry Issues)
 - P0: `request.error` spike with `kind:server`
 
 ### Dashboard baselines

--- a/spec/html2rss/web/sentry_ops_spec.rb
+++ b/spec/html2rss/web/sentry_ops_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Html2rss::Web::SentryOps do
     end
   end
 
-  %w[BLOCKED_SURFACE EXTRACTION_EMPTY].each do |code|
-    it "does not emit a Sentry issue for product-signal code #{code}" do
+  %w[BLOCKED_SURFACE EXTRACTION_EMPTY GATEWAY_TIMEOUT].each do |code|
+    it "does not emit a Sentry issue for non-operational or transient code #{code}" do
       described_class.emit_operational_failure(
         decision: Html2rss::Web::ErrorClassifier.const_get(code),
         diagnostics:,
@@ -91,6 +91,26 @@ RSpec.describe Html2rss::Web::SentryOps do
       details: { error_code: 'SERVICE_UNAVAILABLE', status: 503 }
     )
     expect(capture_store).to include(message: 'request.error: SERVICE_UNAVAILABLE')
+  end
+
+  it 'emits observability but suppresses Sentry issue for GATEWAY_TIMEOUT', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    allow(Html2rss::Web::Observability).to receive(:emit)
+
+    described_class.emit_failure_telemetry(
+      decision: Html2rss::Web::ErrorClassifier::GATEWAY_TIMEOUT,
+      diagnostics:,
+      event_name: 'feed.render',
+      details: { error_code: 'GATEWAY_TIMEOUT', status: 504 },
+      level: :warn
+    )
+
+    expect(Html2rss::Web::Observability).to have_received(:emit).with(
+      event_name: 'feed.render',
+      outcome: 'failure',
+      level: :warn,
+      details: { error_code: 'GATEWAY_TIMEOUT', status: 504 }
+    )
+    expect(capture_store).to be_empty
   end
 
   def operational_decision(code)


### PR DESCRIPTION
## What changed

- Removed `GATEWAY_TIMEOUT` from `SentryOps::OPERATIONAL_CODES` in `app/web/telemetry/sentry_ops.rb`.
- Updated `spec/html2rss/web/sentry_ops_spec.rb` to assert that `GATEWAY_TIMEOUT` does not emit a Sentry Issue while preserving structured stdout telemetry (`Observability.emit`).
- Updated `docs/README.md` § Sentry Runbook to clarify that `SentryOps` captures only P0 server failures (`SCRAPER_UNAVAILABLE`, `SERVICE_UNAVAILABLE`, `INTERNAL_SERVER_ERROR`), and that `GATEWAY_TIMEOUT` is monitored via structured logs rather than Sentry Issues.

## Why

External targets timing out (HTTP 504) were being treated as P0 operational errors in `SentryOps`, triggering `Sentry.capture_message(..., level: :error)` on every target timeout. This treated Sentry as a warning log sink and generated noisy Sentry Issues and notification alerts for expected third-party target slowness.

Target timeouts remain visible in structured stdout logs (`feed.render` / `request.error`) and Sentry breadcrumbs without polluting Sentry Issues.

## Risk

- **Low**: Operators relying solely on Sentry Issues to detect external website downtime will need to monitor structured logs or metric dashboards instead. Internal infrastructure errors (`INTERNAL_SERVER_ERROR`, `SCRAPER_UNAVAILABLE`, `SERVICE_UNAVAILABLE`) and unhandled 500 exceptions continue to capture Sentry Issues.

## Validation

- `bundle exec rspec spec/html2rss/web/sentry_ops_spec.rb` (9 examples, 0 failures)
- `bundle exec rubocop app/web/telemetry/sentry_ops.rb spec/html2rss/web/sentry_ops_spec.rb` (0 offenses)
- `make ready` inside Dev Container (pre-commit checks + 340 rspec examples passing)
- Post-delivery review via `review.gil` worker: Production Readiness **Yes**