### PR TITLE
fix(deps): bump fast-uri override to 3.1.7

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   js-yaml: ^4.3.1
   undici: ^7.28.0
   brace-expansion: ^5.0.8
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.7
   nanoid: ^3.3.17
 
 importers:
@@ -1297,8 +1297,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3315,7 +3315,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3771,7 +3771,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -11,5 +11,5 @@ overrides:
   js-yaml: "^4.3.1"
   undici: "^7.28.0"
   brace-expansion: "^5.0.8"
-  fast-uri: "^3.1.5"
+  fast-uri: "^3.1.7"
   nanoid: "^3.3.17"


### PR DESCRIPTION
## What changed

- Raised the frontend pnpm override `fast-uri` from `^3.1.5` to `^3.1.7` in `frontend/pnpm-workspace.yaml`.
- Refreshed `frontend/pnpm-lock.yaml` so `ajv` resolves `fast-uri@3.1.7`.

## Why

`fast-uri` ≤3.1.5 is affected by URI/SSRF host-confusion advisories patched in ≥3.1.6. Absolute latest is 4.1.4, but `ajv@8.20.0` declares `fast-uri: ^3.0.1`, so 4.x stays blocked without forcing past that range. 3.1.7 is the latest compatible 3.x.

## Risk

- Low — transitive override for Stylelint/AJV tooling only; no app runtime dependency on `fast-uri`.

## Review map

Review map: whole PR is small — start at `frontend/pnpm-workspace.yaml`.

## Validation

- `make ci-ready` in Dev Container (exit 0), including frontend lint/tests and e2e smoke.