### PR TITLE
chore: drop compose and catalog compatibility shims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
       - name: Lint Dockerfile
         run: docker run --rm -i hadolint/hadolint < Dockerfile
 
-  quickstart:
+  compose-contract:
     needs:
       - hadolint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - name: Make compose contract verifier executable
-        run: chmod +x bin/compose-contract-verify bin/quickstart-verify
+        run: chmod +x bin/compose-contract-verify
       - name: Verify compose contracts
         run: bin/compose-contract-verify
 

--- a/bin/quickstart-verify
+++ b/bin/quickstart-verify
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# frozen_string_literal: true
-# Compatibility wrapper — prefer bin/compose-contract-verify.
-set -euo pipefail
-exec "$(dirname "$0")/compose-contract-verify"

--- a/frontend/src/catalog/index.ts
+++ b/frontend/src/catalog/index.ts
@@ -1,5 +1,5 @@
 export type { CatalogEntry, CatalogSnapshot, LastResult, LastResultState } from './types';
 export { UNKNOWN_LAST_RESULT } from './types';
 export { findCatalogEntries, catalogFeedHref } from './findCatalogEntries';
-export { parseCatalog, parseCatalogEntries, selectStarterFeeds } from './parseCatalog';
+export { parseCatalog, selectStarterFeeds } from './parseCatalog';
 export { useCatalogEntries } from './useCatalogEntries';

--- a/frontend/src/catalog/parseCatalog.ts
+++ b/frontend/src/catalog/parseCatalog.ts
@@ -122,13 +122,6 @@ export function parseCatalog(payload: unknown): CatalogSnapshot {
 }
 
 /**
- * @deprecated Prefer {@link parseCatalog}; kept as entries-only adapter.
- */
-export function parseCatalogEntries(payload: unknown): CatalogEntry[] {
-  return parseCatalog(payload).entries;
-}
-
-/**
  * Maps server `meta.starters` to entries. Fallback ranks by last_result
  * (ok → unknown → failing) when starter ids are missing or unmatched.
  */


### PR DESCRIPTION
## Summary
- Remove `bin/quickstart-verify` compatibility wrapper; CI calls `bin/compose-contract-verify` only
- Rename CI job `quickstart` → `compose-contract` to match the real contract
- Delete unused deprecated `parseCatalogEntries` adapter (callers already use `parseCatalog`)

## Test plan
- [x] `bin/compose-contract-verify` exits 0 locally
- [ ] CI `compose-contract` + frontend typecheck/tests green