### PR TITLE
fix(docker): build frontend on BUILDPLATFORM for multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG RUBY_BASE_IMAGE=ruby:4.0.1-alpine3.23@sha256:7d1c4a23da9b3539fdeb5f970950a8fe044a707219e546f12152b84bbd5755d1
 ARG NODE_BASE_IMAGE=node:22-alpine@sha256:8094c002d08262dba12645a3b4a15cd6cd627d30bc782f53229a2ec13ee22a00
 
-# Stage 1: Frontend Build
-FROM ${NODE_BASE_IMAGE} AS frontend-builder
+# Stage 1: Frontend Build (arch-independent assets; native builder, not QEMU)
+FROM --platform=$BUILDPLATFORM ${NODE_BASE_IMAGE} AS frontend-builder
 
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./


### PR DESCRIPTION
## What changed

- Pin `frontend-builder` in `Dockerfile` to `FROM --platform=$BUILDPLATFORM` so Node/pnpm run once on the native builder, not under QEMU for `linux/arm64`.
- Both amd64 and arm64 runtime images still `COPY --from=frontend-builder` the same arch-independent `frontend/dist`.

## Why

### Root cause

Release `docker-publish` (`platforms: linux/amd64,linux/arm64`) rebuilt the frontend twice. On `v1.12.0`, arm64 `pnpm install` stalled for a long time at supply-chain lockfile verification under QEMU (amd64 finished in ~12s). Frontend assets do not need a per-arch Node toolchain.

## Risk

- Low — static Vite/Preact output is platform-independent; Ruby stages still build per target (including QEMU arm64).
- Residual: arm64 Ruby `bundle install` under QEMU remains slow but was not the hang path.

## Validation

- `docker run --rm -i hadolint/hadolint < Dockerfile` (exit 0)
- `docker buildx build --no-cache --platform linux/amd64,linux/arm64 --target frontend-builder --output=type=cacheonly .` — single native `pnpm install` (~18s); no QEMU Node stage
- Dev Container `make ready` (exit 0)