### PR TITLE
fix(sentry): survive sentry-ruby 7 without enable_logs

### DIFF
--- a/app/web/boot/sentry.rb
+++ b/app/web/boot/sentry.rb
@@ -36,9 +36,24 @@ module Html2rss
           def apply_settings(config)
             config.dsn = RuntimeEnv.sentry_dsn
             config.environment = RuntimeEnv.rack_env
-            config.enable_logs = RuntimeEnv.sentry_logs_enabled?
             config.send_default_pii = false
             config.release = release_name
+            apply_log_settings(config)
+          end
+
+          # sentry-ruby 7+ enables structured logs by default and removed
+          # +enable_logs+. Keep +SENTRY_ENABLE_LOGS+ opt-in: patch stdlib
+          # +Logger+ when enabled, otherwise drop log events at send time.
+          #
+          # @param config [Object]
+          # @return [void]
+          def apply_log_settings(config)
+            if RuntimeEnv.sentry_logs_enabled?
+              config.enabled_patches += [:logger]
+              return
+            end
+
+            config.before_send_log = ->(_log) {}
           end
 
           # @return [String]

--- a/docs/README.md
+++ b/docs/README.md
@@ -246,7 +246,7 @@ When triaging `GATEWAY_TIMEOUT`, capacity-shaped `SERVICE_UNAVAILABLE` (queue/bo
 
 With `SENTRY_DSN` set, html2rss-web sends unhandled exceptions (Rack middleware) and P0 operational server failures (`SentryOps`: `SCRAPER_UNAVAILABLE`, `SERVICE_UNAVAILABLE`, `INTERNAL_SERVER_ERROR`) to Sentry Issues. Transient target timeouts (`GATEWAY_TIMEOUT`) and extraction warnings stay in structured stdout logs (`feed.render` / `request.error`) and Sentry breadcrumbs to prevent alert fatigue from slow external websites. Release is `BUILD_TAG+GIT_SHA`; environment is `RACK_ENV`.
 
-Structured log intake is opt-in: set `SENTRY_ENABLE_LOGS=true`. A DSN alone does not enable `SentryLogs`.
+Structured log intake is opt-in: set `SENTRY_ENABLE_LOGS=true`. A DSN alone does not enable `SentryLogs` or the stdlib `Logger` → Sentry patch.
 
 Start triage from the newest `feed.create`, `feed.render`, and `request.error` events. Check release, route group, strategy, and outcome.
 

--- a/spec/html2rss/web/boot/sentry_spec.rb
+++ b/spec/html2rss/web/boot/sentry_spec.rb
@@ -6,7 +6,10 @@ require_relative '../../../../app'
 
 RSpec.describe Html2rss::Web::Boot::Sentry do
   let(:sentry_dsn) { 'https://example@sentry.invalid/1' }
-  let(:captured_config) { Struct.new(:dsn, :environment, :enable_logs, :send_default_pii, :release).new }
+  let(:captured_config) do
+    Struct.new(:dsn, :environment, :before_send_log, :enabled_patches, :send_default_pii, :release)
+          .new(nil, nil, nil, [])
+  end
   let(:captured_scope) do
     Class.new do
       attr_reader :tags
@@ -46,20 +49,28 @@ RSpec.describe Html2rss::Web::Boot::Sentry do
     expect_sentry_configuration
   end
 
+  it 'patches stdlib Logger when SENTRY_ENABLE_LOGS is true', :aggregate_failures do
+    stub_runtime_env_for_sentry('production', sentry_logs_enabled: true)
+    described_class.send(:initialize_sentry!)
+
+    expect(captured_config.before_send_log).to be_nil
+    expect(captured_config.enabled_patches).to include(:logger)
+  end
+
   it 'does nothing when a dsn is not present' do
     allow(Html2rss::Web::RuntimeEnv).to receive(:sentry_enabled?).and_return(false)
 
     expect(described_class.send(:configure?)).to be(false)
   end
 
-  def stub_runtime_env_for_sentry(rack_env)
+  def stub_runtime_env_for_sentry(rack_env, sentry_logs_enabled: false)
     allow(Html2rss::Web::RuntimeEnv).to receive_messages(
       sentry_enabled?: true,
       sentry_dsn: sentry_dsn,
       rack_env: rack_env,
       build_tag: '2026-03-27',
       git_sha: 'abc1234',
-      sentry_logs_enabled?: false
+      sentry_logs_enabled?: sentry_logs_enabled
     )
   end
 
@@ -67,11 +78,17 @@ RSpec.describe Html2rss::Web::Boot::Sentry do
     expect(captured_config).to have_attributes(
       dsn: sentry_dsn,
       environment: 'production',
-      enable_logs: false,
       send_default_pii: false,
       release: '2026-03-27+abc1234'
     )
+    expect_log_intake_disabled(captured_config)
     expect_sentry_scope_tags
+  end
+
+  def expect_log_intake_disabled(config)
+    expect(config.before_send_log).to be_a(Proc)
+    expect(config.before_send_log.call(Object.new)).to be_nil
+    expect(config.enabled_patches).not_to include(:logger)
   end
 
   def expect_sentry_scope_tags

--- a/spec/html2rss/web/boot/setup_spec.rb
+++ b/spec/html2rss/web/boot/setup_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe Html2rss::Web::Boot::Setup do
         described_class.call!
       end
 
-      expect_sentry_config(:enable_logs, true)
+      expect(Sentry.captured_config.before_send_log).to be_nil
+      expect(Sentry.captured_config.enabled_patches).to include(:logger)
     end
 
     it 'fails fast when SENTRY_ENABLE_LOGS is malformed' do
@@ -191,8 +192,14 @@ RSpec.describe Html2rss::Web::Boot::Setup do
   def expect_sentry_to_be_configured
     expect(Bundler).to have_received(:require).with(:sentry)
     expect_sentry_config(:dsn, sentry_dsn)
-    expect_sentry_config(:enable_logs, false)
     expect_sentry_config(:release, '2026-03-27+abc1234')
+    expect_log_intake_disabled(Sentry.captured_config)
+  end
+
+  def expect_log_intake_disabled(config)
+    expect(config.before_send_log).to be_a(Proc)
+    expect(config.before_send_log.call(Object.new)).to be_nil
+    expect(config.enabled_patches).not_to include(:logger)
   end
 
   def build_fake_sentry
@@ -231,6 +238,7 @@ RSpec.describe Html2rss::Web::Boot::Setup do
   end
 
   def build_fake_sentry_config
-    Struct.new(:dsn, :environment, :enable_logs, :send_default_pii, :release).new
+    Struct.new(:dsn, :environment, :before_send_log, :enabled_patches, :send_default_pii, :release)
+          .new(nil, nil, nil, [])
   end
 end


### PR DESCRIPTION
## What changed

- `app/web/boot/sentry.rb`: stop setting removed `config.enable_logs=` (boot crash on sentry-ruby 7.0 with `SENTRY_DSN` set)
- When `SENTRY_ENABLE_LOGS=true`: `enabled_patches += [:logger]` so stdlib `Logger` forwards to Sentry
- When logs are off (default): `before_send_log` drops log events so intake stays opt-in
- Specs + docs aligned with the new knobs

## Why

### Root cause

Published images with a DSN failed smoke at boot:

`undefined method 'enable_logs=' for an instance of Sentry::Configuration`

sentry-ruby 7 enables logs by default and removed `enable_logs`.

## Risk

- Low — boot path only; default still keeps log intake off
- With `SENTRY_ENABLE_LOGS=true`, `AppLogger` structured `SentryLogs` emit and the Logger patch can both fire for the same line (possible duplicate log events)

## Review map

Review map: whole PR is small — start at `app/web/boot/sentry.rb`.

## Validation

- Dev Container: `bundle exec rspec` boot sentry/setup specs — 0 failures
- Dev Container: real `Sentry.init` smoke with DSN — ok
- Dev Container: `make ready` — 343 examples, 0 failures